### PR TITLE
.trim in originalFilename

### DIFF
--- a/src/aws/aws.service.ts
+++ b/src/aws/aws.service.ts
@@ -27,7 +27,7 @@ export class AwsService {
     variant_id: number,
   ): Promise<HttpStatus> {
     try {
-      const imageUrl = `${this.bucketUrl}${originalname}`;
+      const imageUrl = `${this.bucketUrl}${originalname.trim()}`;
 
       const { codpro, pathfoto2 } = await this.prisma.stock.findFirst({
         where: { id: variant_id },


### PR DESCRIPTION
Agrege un .trim() en el nombre original de las imagenes  ya que al subir una imagen con espacios en blanco rompe